### PR TITLE
Dependabot

### DIFF
--- a/MyComicsManagerApi.csproj
+++ b/MyComicsManagerApi.csproj
@@ -15,15 +15,15 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.3" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
     <PackageReference Include="PdfPig" Version="0.1.5" />
-    <PackageReference Include="sharpcompress" Version="0.30.1" />
+    <PackageReference Include="sharpcompress" Version="0.31.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     <PackageReference Include="Hangfire.Core" Version="1.7.28" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.28" />
-    <PackageReference Include="Hangfire.Mongo" Version="0.7.28" />
+    <PackageReference Include="Hangfire.Mongo" Version="1.7.0" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Bump sharpcompress from 0.30.1 to 0.31.0
Bump Swashbuckle.AspNetCore from 6.2.3 to 6.3.0
Bump Hangfire.Mongo from 0.7.28 to 1.7.0
Bump MongoDB.Driver from 2.14.1 to 2.15.0